### PR TITLE
feat: 风格迁移 Demo 增强 — SSE 步骤动画 + GPU/CPU 设备检测

### DIFF
--- a/demos/2026-04-07_style-transfer/backend/app.py
+++ b/demos/2026-04-07_style-transfer/backend/app.py
@@ -1,12 +1,15 @@
 """
 图片风格迁移 Demo — FastAPI 后端
 使用 PyTorch + VGG19 实现神经风格迁移
+支持 SSE 实时推送处理步骤状态
 """
 
 import io
 import os
+import json
 import uuid
 import time
+import base64
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -16,7 +19,7 @@ import numpy as np
 from PIL import Image
 from fastapi import FastAPI, UploadFile, File, Form, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 import uvicorn
 
 app = FastAPI(title="🎨 图片风格迁移 Demo", version="1.0.0")
@@ -293,20 +296,29 @@ def build_model_and_losses(content_img, style_img, style_layers_weights):
     return model, content_losses, style_losses
 
 
-def run_style_transfer(content_img, style_key, preset):
+def run_style_transfer(content_img, style_key, preset, step_callback=None):
     """
     执行风格迁移主流程
+    step_callback: 可选回调函数 (step_id: str, message: str, details: dict|None) -> None
     返回风格化后的图片 Tensor
     """
     # 生成程序化风格参考图
     style_img = generate_style_image(style_key, content_img.size())
+    if step_callback:
+        step_callback("style_generated", "风格参考图已生成")
 
     # 输入图片初始化为内容图片的副本
     input_img = content_img.clone()
 
+    if step_callback:
+        step_callback("building_model", "正在构建 VGG19 模型并插入损失层...")
+
     model, content_losses, style_losses = build_model_and_losses(
         content_img, style_img, preset["style_layers_weights"]
     )
+
+    if step_callback:
+        step_callback("model_ready", f"模型构建完成，使用 {len(content_losses)} 个内容层 + {len(style_losses)} 个风格层")
 
     # 优化器直接优化像素值
     input_img.requires_grad_(True)
@@ -318,6 +330,8 @@ def run_style_transfer(content_img, style_key, preset):
     content_weight = preset["content_weight"]
 
     step = [0]
+    last_reported = [0]
+
     while step[0] < num_steps:
         def closure():
             input_img.data.clamp_(0, 1)
@@ -334,11 +348,30 @@ def run_style_transfer(content_img, style_key, preset):
             total_loss.backward()
 
             step[0] += 1
+
+            # 每 10% 进度回调一次
+            if step_callback:
+                pct = int(step[0] / num_steps * 100)
+                if pct >= last_reported[0] + 10 or step[0] == num_steps:
+                    last_reported[0] = pct
+                    step_callback("optimizing", f"迭代优化中 {step[0]}/{num_steps} ({pct}%)", {
+                        "step": step[0],
+                        "total_steps": num_steps,
+                        "progress": pct,
+                        "content_loss": round(c_loss.item(), 4),
+                        "style_loss": round(s_loss.item(), 4),
+                        "total_loss": round(total_loss.item(), 4),
+                    })
+
             return total_loss
 
         optimizer.step(closure)
 
     input_img.data.clamp_(0, 1)
+
+    if step_callback:
+        step_callback("optimization_done", "迭代优化完成")
+
     return input_img
 
 
@@ -459,6 +492,194 @@ async def download_file(filename: str):
     if not os.path.exists(filepath):
         raise HTTPException(status_code=404, detail="文件不存在")
     return FileResponse(filepath, media_type="image/png", filename=filename)
+
+
+# ==================== SSE 步骤定义 ====================
+
+# 风格迁移处理流水线的 6 个步骤
+TRANSFER_STEPS = [
+    {"step": 1, "total": 6, "name": "接收图片", "emoji": "📤", "description": "读取上传的内容图和风格图"},
+    {"step": 2, "total": 6, "name": "图像预处理", "emoji": "🔧", "description": "缩放至统一尺寸并归一化"},
+    {"step": 3, "total": 6, "name": "VGG19 特征提取", "emoji": "🧠", "description": "提取内容特征与风格特征"},
+    {"step": 4, "total": 6, "name": "Gram 矩阵计算", "emoji": "📐", "description": "计算风格纹理的 Gram 矩阵"},
+    {"step": 5, "total": 6, "name": "L-BFGS 迭代优化", "emoji": "🔄", "description": "迭代生成风格化图像"},
+    {"step": 6, "total": 6, "name": "输出结果", "emoji": "🎨", "description": "返回最终风格迁移图片"},
+]
+
+
+def _sse_event(data: dict) -> str:
+    """将字典序列化为 SSE 格式的 data 行"""
+    return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+def _emit_step(step_info: dict, status: str) -> str:
+    """生成一条步骤事件"""
+    return _sse_event({**step_info, "status": status})
+
+
+def run_style_transfer_stream(content_img, style_key, preset):
+    """
+    执行风格迁移主流程（生成器版本），每个步骤产出 SSE 事件。
+    最终 yield 包含 base64 结果图片的事件。
+    """
+    # ---- Step 1: 接收图片 ----
+    yield _emit_step(TRANSFER_STEPS[0], "running")
+    style_img = generate_style_image(style_key, content_img.size())
+    input_img = content_img.clone()
+    yield _emit_step(TRANSFER_STEPS[0], "done")
+
+    # ---- Step 2: 图像预处理（已在 load_image 完成，这里确认归一化参数） ----
+    yield _emit_step(TRANSFER_STEPS[1], "running")
+    normalization_mean = torch.tensor([0.485, 0.456, 0.406]).to(DEVICE)
+    normalization_std = torch.tensor([0.229, 0.224, 0.225]).to(DEVICE)
+    yield _emit_step(TRANSFER_STEPS[1], "done")
+
+    # ---- Step 3: VGG19 特征提取 ----
+    yield _emit_step(TRANSFER_STEPS[2], "running")
+    vgg = models.vgg19(weights=models.VGG19_Weights.DEFAULT).features.to(DEVICE).eval()
+    normalization_layer = Normalization(normalization_mean, normalization_std)
+    yield _emit_step(TRANSFER_STEPS[2], "done")
+
+    # ---- Step 4: Gram 矩阵计算（构建模型并插入损失层） ----
+    yield _emit_step(TRANSFER_STEPS[3], "running")
+    content_losses = []
+    style_losses = []
+    model = nn.Sequential(normalization_layer)
+    content_layers = ["conv_4"]
+    style_layers = list(preset["style_layers_weights"].keys())
+
+    i = 0
+    for layer in vgg.children():
+        if isinstance(layer, nn.Conv2d):
+            i += 1
+            name = f"conv_{i}"
+        elif isinstance(layer, nn.ReLU):
+            name = f"relu_{i}"
+            layer = nn.ReLU(inplace=False)
+        elif isinstance(layer, nn.MaxPool2d):
+            name = f"pool_{i}"
+        elif isinstance(layer, nn.BatchNorm2d):
+            name = f"bn_{i}"
+        else:
+            continue
+
+        model.add_module(name, layer)
+
+        if name in content_layers:
+            target = model(content_img).detach()
+            content_loss = ContentLoss(target)
+            model.add_module(f"content_loss_{i}", content_loss)
+            content_losses.append(content_loss)
+
+        if name in style_layers:
+            target_feature = model(style_img).detach()
+            style_loss = StyleLoss(target_feature)
+            model.add_module(f"style_loss_{i}", style_loss)
+            style_losses.append((style_loss, preset["style_layers_weights"][name]))
+
+    # 裁剪模型
+    for idx in range(len(model) - 1, -1, -1):
+        if isinstance(model[idx], (ContentLoss, StyleLoss)):
+            break
+    model = model[:idx + 1]
+    yield _emit_step(TRANSFER_STEPS[3], "done")
+
+    # ---- Step 5: L-BFGS 迭代优化 ----
+    yield _emit_step(TRANSFER_STEPS[4], "running")
+    input_img.requires_grad_(True)
+    model.requires_grad_(False)
+    optimizer = optim.LBFGS([input_img])
+
+    num_steps = preset["num_steps"]
+    style_weight = preset["style_weight"]
+    content_weight = preset["content_weight"]
+
+    step_counter = [0]
+    while step_counter[0] < num_steps:
+        def closure():
+            input_img.data.clamp_(0, 1)
+            optimizer.zero_grad()
+            model(input_img)
+            c_loss = sum(cl.loss for cl in content_losses) * content_weight
+            s_loss = sum(sl.loss * w for sl, w in style_losses) * style_weight
+            total_loss = c_loss + s_loss
+            total_loss.backward()
+            step_counter[0] += 1
+            return total_loss
+        optimizer.step(closure)
+
+    input_img.data.clamp_(0, 1)
+    yield _emit_step(TRANSFER_STEPS[4], "done")
+
+    # ---- Step 6: 输出结果 ----
+    yield _emit_step(TRANSFER_STEPS[5], "running")
+    output_image = tensor_to_image(input_img)
+    output_id = str(uuid.uuid4())
+    output_path = os.path.join(OUTPUT_DIR, f"{output_id}.png")
+    output_image.save(output_path, "PNG")
+
+    # 将结果图片编码为 base64
+    buf = io.BytesIO()
+    output_image.save(buf, format="PNG")
+    img_base64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+    yield _emit_step(TRANSFER_STEPS[5], "done")
+
+    # 发送最终结果
+    yield _sse_event({
+        "type": "result",
+        "output_id": output_id,
+        "download_url": f"/download/{output_id}.png",
+        "image_base64": img_base64,
+    })
+
+
+@app.post("/transfer-stream")
+async def transfer_stream(file_id: str = Form(...), style: str = Form(...)):
+    """
+    SSE 版本的风格迁移接口：实时推送每个处理步骤的状态
+    参数：
+    - file_id: 上传图片返回的文件 ID
+    - style: 风格 key（oil_painting / sketch / watercolor / impressionist）
+    返回 text/event-stream，逐步推送 6 个步骤的 running/done 状态，最后推送结果
+    """
+    # 验证风格参数
+    if style not in STYLE_PRESETS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"不支持的风格：{style}，可选：{list(STYLE_PRESETS.keys())}"
+        )
+
+    # 查找上传的文件
+    upload_file = None
+    for fname in os.listdir(UPLOAD_DIR):
+        if fname.startswith(file_id):
+            upload_file = os.path.join(UPLOAD_DIR, fname)
+            break
+
+    if not upload_file or not os.path.exists(upload_file):
+        raise HTTPException(status_code=404, detail="图片未找到，请重新上传")
+
+    # 读取图片
+    with open(upload_file, "rb") as f:
+        image_bytes = f.read()
+
+    preset = STYLE_PRESETS[style]
+    content_img = load_image(image_bytes)
+
+    def event_generator():
+        """SSE 事件生成器"""
+        yield from run_style_transfer_stream(content_img, style, preset)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 if __name__ == "__main__":

--- a/demos/2026-04-07_style-transfer/backend/app.py
+++ b/demos/2026-04-07_style-transfer/backend/app.py
@@ -10,6 +10,7 @@ import json
 import uuid
 import time
 import base64
+import subprocess
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -386,6 +387,70 @@ async def health_check():
         "img_size": IMG_SIZE,
         "gpu_available": torch.cuda.is_available(),
     }
+
+
+@app.get("/device-info")
+async def device_info():
+    """
+    返回 GPU/CPU 设备详细检测信息
+    包含设备类型、GPU 是否可用、CUDA 版本、诊断原因和安装建议
+    """
+    cuda_available = torch.cuda.is_available()
+    result = {
+        "device": str(DEVICE),
+        "gpu_available": cuda_available,
+        "gpu_name": None,
+        "cuda_available": cuda_available,
+        "cuda_version": None,
+        "reason": "",
+        "suggestion": "",
+    }
+
+    if cuda_available:
+        # CUDA 可用，获取 GPU 详细信息
+        result["gpu_name"] = torch.cuda.get_device_name(0)
+        result["cuda_version"] = torch.version.cuda
+        result["reason"] = f"已启用 GPU 加速（{result['gpu_name']}），CUDA {result['cuda_version']}"
+        result["suggestion"] = "当前已使用 GPU，无需额外配置。GPU 模式下图片处理分辨率为 512px，速度约为 CPU 的 5-10 倍。"
+    else:
+        # CUDA 不可用，尝试检测是否有物理 GPU
+        has_physical_gpu = False
+        gpu_model = None
+        try:
+            nvsmi = subprocess.run(
+                ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+                capture_output=True, text=True, timeout=5
+            )
+            if nvsmi.returncode == 0 and nvsmi.stdout.strip():
+                has_physical_gpu = True
+                gpu_model = nvsmi.stdout.strip().split("\n")[0].strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+        if has_physical_gpu and gpu_model:
+            # 有物理 GPU 但 PyTorch 无 CUDA 支持
+            result["gpu_name"] = gpu_model
+            result["reason"] = (
+                f"检测到 NVIDIA GPU（{gpu_model}），但 PyTorch 未编译 CUDA 支持，当前使用 CPU。"
+                "可能原因：安装的是 CPU 版 PyTorch，或 CUDA Toolkit 版本不匹配。"
+            )
+            result["suggestion"] = (
+                "1. 确认 GPU 型号（NVIDIA）并安装对应的 CUDA Toolkit（推荐 11.8 或 12.x）\n"
+                "2. 安装 PyTorch GPU 版本：pip install torch torchvision --index-url https://download.pytorch.org/whl/cu118\n"
+                "3. 重启服务后即可启用 GPU 加速\n"
+                "4. GPU 模式下处理速度约为 CPU 的 5-10 倍，分辨率可提升至 512px"
+            )
+        else:
+            # 没有物理 GPU
+            result["reason"] = "未检测到 NVIDIA GPU，使用 CPU 运算。风格迁移速度较慢，单张图片预计 15-60 秒。"
+            result["suggestion"] = (
+                "1. 如果您有 NVIDIA GPU，请确认已安装最新显卡驱动\n"
+                "2. 安装 CUDA Toolkit（推荐 11.8 或 12.x）\n"
+                "3. 安装 PyTorch GPU 版本：pip install torch torchvision --index-url https://download.pytorch.org/whl/cu118\n"
+                "4. 如果没有独立 GPU，可考虑使用 Google Colab 或其他云 GPU 环境"
+            )
+
+    return result
 
 
 @app.get("/styles")

--- a/demos/2026-04-07_style-transfer/frontend/index.html
+++ b/demos/2026-04-07_style-transfer/frontend/index.html
@@ -13,13 +13,13 @@
     min-height: 100vh;
   }
   .container { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem; }
-  
+
   /* 顶部 */
   header { text-align: center; margin-bottom: 2rem; }
   header h1 { font-size: 2rem; margin-bottom: 0.5rem; }
   header h1 span { font-size: 2.4rem; }
   header p { color: #94a3b8; font-size: 0.95rem; }
-  
+
   /* 状态指示器 */
   .status-bar {
     display: flex; align-items: center; justify-content: center;
@@ -32,7 +32,7 @@
   }
   .status-dot.online { background: #22c55e; }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
-  
+
   /* 上传区 */
   .upload-zone {
     border: 2px dashed #334155; border-radius: 12px;
@@ -45,7 +45,7 @@
   .upload-zone .icon { font-size: 3rem; margin-bottom: 1rem; }
   .upload-zone p { color: #94a3b8; }
   .upload-zone input { display: none; }
-  
+
   /* 预览 */
   .preview-area {
     display: none; margin-bottom: 2rem; text-align: center;
@@ -57,7 +57,7 @@
   .preview-area .file-info {
     margin-top: 0.5rem; font-size: 0.85rem; color: #94a3b8;
   }
-  
+
   /* 风格选择 */
   .styles-section { margin-bottom: 2rem; }
   .styles-section h3 { margin-bottom: 1rem; font-size: 1.1rem; }
@@ -75,7 +75,7 @@
   .style-card .emoji { font-size: 2rem; margin-bottom: 0.5rem; }
   .style-card .name { font-weight: 600; margin-bottom: 0.3rem; }
   .style-card .desc { font-size: 0.8rem; color: #94a3b8; }
-  
+
   /* 开始按钮 */
   .action-bar { text-align: center; margin-bottom: 2rem; }
   .btn-transfer {
@@ -88,8 +88,74 @@
   .btn-transfer:disabled {
     opacity: 0.5; cursor: not-allowed; transform: none; box-shadow: none;
   }
-  
-  /* 进度条 */
+
+  /* ========== 动态流水线 ========== */
+  .pipeline-section {
+    display: none; margin-bottom: 2rem; padding: 1.5rem 1rem;
+    background: #1e293b; border-radius: 10px; border: 1px solid #334155;
+  }
+  .pipeline-section h3 {
+    text-align: center; margin-bottom: 1.2rem; font-size: 1rem;
+  }
+  /* 横向流水线容器 */
+  .pipeline-track {
+    display: flex; align-items: center; justify-content: center;
+    gap: 0; overflow-x: auto; padding: 0.5rem 0;
+  }
+  /* 单个步骤节点 */
+  .pipeline-node {
+    display: flex; flex-direction: column; align-items: center;
+    min-width: 80px; position: relative;
+  }
+  .pipeline-node .node-circle {
+    width: 44px; height: 44px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.25rem; border: 2px solid #475569;
+    background: #1e293b; transition: all 0.4s; position: relative;
+  }
+  .pipeline-node .node-label {
+    margin-top: 0.4rem; font-size: 0.72rem; color: #64748b;
+    text-align: center; white-space: nowrap; transition: color 0.4s;
+  }
+  /* 节点状态：待执行（默认） */
+  .pipeline-node.pending .node-circle { border-color: #475569; color: #64748b; }
+  /* 节点状态：执行中 */
+  .pipeline-node.running .node-circle {
+    border-color: #38bdf8; color: #fff;
+    box-shadow: 0 0 12px rgba(56,189,248,0.5);
+    animation: breathe 1.5s ease-in-out infinite;
+  }
+  .pipeline-node.running .node-label { color: #38bdf8; font-weight: 600; }
+  /* 节点状态：完成 */
+  .pipeline-node.done .node-circle {
+    border-color: #22c55e; background: #22c55e; color: #fff;
+  }
+  .pipeline-node.done .node-label { color: #22c55e; }
+  /* 完成后显示打勾覆盖 */
+  .pipeline-node.done .node-circle::after {
+    content: "✓"; position: absolute; font-size: 1.1rem; font-weight: bold;
+  }
+  .pipeline-node.done .node-circle .node-emoji { visibility: hidden; }
+
+  @keyframes breathe {
+    0%, 100% { box-shadow: 0 0 8px rgba(56,189,248,0.4); }
+    50% { box-shadow: 0 0 20px rgba(56,189,248,0.7); }
+  }
+
+  /* 连接线 */
+  .pipeline-connector {
+    width: 32px; height: 2px; background: #475569;
+    flex-shrink: 0; transition: background 0.4s; margin-top: -1.2rem;
+  }
+  .pipeline-connector.done { background: #22c55e; }
+
+  /* 步骤描述文字 */
+  .pipeline-desc {
+    text-align: center; margin-top: 1rem; font-size: 0.85rem;
+    color: #94a3b8; min-height: 1.2em; transition: color 0.3s;
+  }
+
+  /* 进度条（用于迭代优化时） */
   .progress-section {
     display: none; margin-bottom: 2rem; padding: 1.5rem;
     background: #1e293b; border-radius: 10px;
@@ -105,7 +171,7 @@
   .progress-section .time-info {
     margin-top: 0.5rem; font-size: 0.8rem; color: #94a3b8;
   }
-  
+
   /* 结果对比 */
   .result-section { display: none; margin-bottom: 2rem; }
   .result-section h3 { text-align: center; margin-bottom: 1rem; }
@@ -120,7 +186,7 @@
   .compare-item img {
     width: 100%; border-radius: 8px; border: 1px solid #334155;
   }
-  
+
   /* 下载按钮 */
   .download-bar { text-align: center; margin-top: 1rem; }
   .btn-download {
@@ -130,28 +196,16 @@
     transition: all 0.3s;
   }
   .btn-download:hover { background: #16a34a; transform: scale(1.03); }
-  
-  /* 流程说明 */
-  .pipeline-section {
-    margin-top: 2rem; padding: 1.5rem;
-    background: #1e293b; border-radius: 10px;
-    border: 1px solid #334155;
-  }
-  .pipeline-section h3 { margin-bottom: 0.8rem; font-size: 1rem; }
-  .pipeline-steps {
-    display: flex; flex-wrap: wrap; align-items: center;
-    gap: 0.4rem; font-size: 0.85rem; color: #94a3b8; line-height: 1.8;
-  }
-  .pipeline-steps .step {
-    background: #334155; padding: 0.3rem 0.7rem;
-    border-radius: 6px; white-space: nowrap;
-  }
-  .pipeline-steps .arrow { color: #6366f1; font-weight: bold; }
 
   /* 响应式 */
   @media (max-width: 600px) {
     .compare-grid { grid-template-columns: 1fr; }
     .style-grid { grid-template-columns: 1fr 1fr; }
+    .pipeline-track { flex-wrap: wrap; gap: 0.3rem; justify-content: center; }
+    .pipeline-connector { width: 20px; }
+    .pipeline-node { min-width: 60px; }
+    .pipeline-node .node-circle { width: 36px; height: 36px; font-size: 1rem; }
+    .pipeline-node .node-label { font-size: 0.65rem; }
   }
 </style>
 </head>
@@ -194,7 +248,16 @@
     <button class="btn-transfer" id="btnTransfer" disabled>✨ 开始风格迁移</button>
   </div>
 
-  <!-- 进度 -->
+  <!-- 动态流水线 -->
+  <div class="pipeline-section" id="pipelineSection">
+    <h3>📋 风格迁移处理流程</h3>
+    <div class="pipeline-track" id="pipelineTrack">
+      <!-- 由 JS 动态生成 -->
+    </div>
+    <div class="pipeline-desc" id="pipelineDesc"></div>
+  </div>
+
+  <!-- 进度条（迭代优化时的二级进度） -->
   <div class="progress-section" id="progressSection">
     <div class="label" id="progressLabel">⏳ 正在处理中...</div>
     <div class="progress-bar-bg">
@@ -220,24 +283,6 @@
       <a class="btn-download" id="btnDownload" download>⬇️ 下载风格化图片</a>
     </div>
   </div>
-
-  <!-- 处理流程说明 -->
-  <div class="pipeline-section">
-    <h3>📋 风格迁移处理流程</h3>
-    <div class="pipeline-steps">
-      <span class="step">📤 上传图片</span>
-      <span class="arrow">→</span>
-      <span class="step">🔧 图像预处理（缩放至统一尺寸并归一化）</span>
-      <span class="arrow">→</span>
-      <span class="step">🧠 VGG19 提取内容特征与风格特征</span>
-      <span class="arrow">→</span>
-      <span class="step">📐 计算 Gram 矩阵匹配风格纹理</span>
-      <span class="arrow">→</span>
-      <span class="step">🔄 L-BFGS 迭代优化生成图像</span>
-      <span class="arrow">→</span>
-      <span class="step">🎨 输出风格化结果</span>
-    </div>
-  </div>
 </div>
 
 <script>
@@ -245,6 +290,70 @@ const API = 'http://localhost:8000';
 let fileId = null;
 let selectedStyle = null;
 let uploadedFile = null;
+
+// 6 个步骤的元信息（与后端 TRANSFER_STEPS 对应）
+const STEPS = [
+  { step: 1, emoji: '📤', name: '接收图片' },
+  { step: 2, emoji: '🔧', name: '图像预处理' },
+  { step: 3, emoji: '🧠', name: 'VGG19 特征提取' },
+  { step: 4, emoji: '📐', name: 'Gram 矩阵计算' },
+  { step: 5, emoji: '🔄', name: 'L-BFGS 迭代优化' },
+  { step: 6, emoji: '🎨', name: '输出结果' },
+];
+
+// === 初始化流水线 DOM ===
+function initPipeline() {
+  const track = document.getElementById('pipelineTrack');
+  track.innerHTML = '';
+  STEPS.forEach((s, i) => {
+    // 节点
+    const node = document.createElement('div');
+    node.className = 'pipeline-node pending';
+    node.id = `pnode-${s.step}`;
+    node.innerHTML = `
+      <div class="node-circle"><span class="node-emoji">${s.emoji}</span></div>
+      <div class="node-label">${s.name}</div>
+    `;
+    track.appendChild(node);
+    // 连线（最后一个步骤后面不加）
+    if (i < STEPS.length - 1) {
+      const conn = document.createElement('div');
+      conn.className = 'pipeline-connector';
+      conn.id = `pconn-${s.step}`;
+      track.appendChild(conn);
+    }
+  });
+}
+
+// 更新某一步的状态
+function setPipelineStep(stepNum, status, description) {
+  const node = document.getElementById(`pnode-${stepNum}`);
+  if (!node) return;
+  node.className = `pipeline-node ${status}`;
+
+  // 如果完成，连线也变绿
+  if (status === 'done') {
+    const conn = document.getElementById(`pconn-${stepNum}`);
+    if (conn) conn.classList.add('done');
+  }
+
+  // 更新描述
+  if (description) {
+    document.getElementById('pipelineDesc').textContent =
+      `${STEPS[stepNum - 1].emoji} ${description}`;
+  }
+}
+
+// 重置所有流水线节点
+function resetPipeline() {
+  STEPS.forEach(s => {
+    const node = document.getElementById(`pnode-${s.step}`);
+    if (node) node.className = 'pipeline-node pending';
+    const conn = document.getElementById(`pconn-${s.step}`);
+    if (conn) conn.classList.remove('done');
+  });
+  document.getElementById('pipelineDesc').textContent = '';
+}
 
 // === 初始化 ===
 async function checkHealth() {
@@ -315,9 +424,9 @@ fileInput.addEventListener('change', () => {
 async function handleFile(file) {
   if (!file.type.startsWith('image/')) { alert('请选择图片文件'); return; }
   if (file.size > 10*1024*1024) { alert('图片不能超过 10MB'); return; }
-  
+
   uploadedFile = file;
-  
+
   // 本地预览
   const reader = new FileReader();
   reader.onload = e => {
@@ -344,7 +453,7 @@ async function handleFile(file) {
   }
 }
 
-// === 风格迁移 ===
+// === 风格迁移（SSE 版本） ===
 document.getElementById('btnTransfer').addEventListener('click', startTransfer);
 
 async function startTransfer() {
@@ -354,50 +463,121 @@ async function startTransfer() {
   btn.disabled = true;
   btn.textContent = '⏳ 处理中...';
 
-  // 显示进度
-  const progressSection = document.getElementById('progressSection');
-  progressSection.style.display = 'block';
+  // 显示流水线，隐藏结果
+  const pipelineSection = document.getElementById('pipelineSection');
+  pipelineSection.style.display = 'block';
   document.getElementById('resultSection').style.display = 'none';
+  document.getElementById('progressSection').style.display = 'none';
+  initPipeline();
 
-  // 模拟进度（实际是同步的，但给用户视觉反馈）
-  let progress = 0;
-  const progressBar = document.getElementById('progressBar');
   const startTime = Date.now();
-  const timer = setInterval(() => {
-    progress = Math.min(progress + Math.random() * 3, 90);
-    progressBar.style.width = progress + '%';
-    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-    document.getElementById('timeInfo').textContent = `已用时 ${elapsed} 秒`;
-  }, 500);
 
   try {
+    // 使用 fetch + ReadableStream 连接 SSE 接口
     const formData = new FormData();
     formData.append('file_id', fileId);
     formData.append('style', selectedStyle);
 
-    const r = await fetch(`${API}/style_transfer`, { method: 'POST', body: formData });
-    const data = await r.json();
-    if (!r.ok) throw new Error(data.detail);
+    const response = await fetch(`${API}/transfer-stream`, {
+      method: 'POST',
+      body: formData,
+    });
 
-    clearInterval(timer);
-    progressBar.style.width = '100%';
-    document.getElementById('progressLabel').textContent = '✅ 处理完成！';
-    document.getElementById('timeInfo').textContent = `总耗时 ${data.processing_time} 秒 (${data.device})`;
+    if (!response.ok) {
+      const err = await response.json();
+      throw new Error(err.detail || '请求失败');
+    }
 
-    // 显示结果
-    const resultSection = document.getElementById('resultSection');
-    document.getElementById('originalImg').src = document.getElementById('previewImg').src;
-    document.getElementById('resultImg').src = `${API}${data.download_url}`;
-    document.getElementById('resultLabel').textContent = `${getStyleEmoji(selectedStyle)} ${data.style_name}`;
-    document.getElementById('btnDownload').href = `${API}${data.download_url}`;
-    resultSection.style.display = 'block';
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // 按 SSE 协议解析：每条消息以 \n\n 分隔
+      const parts = buffer.split('\n\n');
+      // 最后一段可能不完整，保留在 buffer 中
+      buffer = parts.pop() || '';
+
+      for (const part of parts) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+
+        // 提取 data: 后面的 JSON
+        const lines = trimmed.split('\n');
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            try {
+              const data = JSON.parse(line.slice(6));
+              handleSSEEvent(data, startTime);
+            } catch (e) {
+              console.warn('SSE 解析失败:', line, e);
+            }
+          }
+        }
+      }
+    }
   } catch(e) {
-    clearInterval(timer);
-    document.getElementById('progressLabel').textContent = '❌ 处理失败：' + e.message;
+    document.getElementById('pipelineDesc').textContent = '❌ 处理失败：' + e.message;
+    document.getElementById('pipelineDesc').style.color = '#ef4444';
   }
 
   btn.disabled = false;
   btn.textContent = '✨ 开始风格迁移';
+}
+
+function handleSSEEvent(data, startTime) {
+  // 步骤事件（包含 step 字段）
+  if (data.step !== undefined && data.status) {
+    setPipelineStep(data.step, data.status, data.description);
+
+    // 步骤 5 执行中时显示进度条
+    if (data.step === 5 && data.status === 'running') {
+      document.getElementById('progressSection').style.display = 'block';
+      document.getElementById('progressLabel').textContent = '🔄 L-BFGS 迭代优化中...';
+      document.getElementById('progressBar').style.width = '10%';
+    }
+    if (data.step === 5 && data.status === 'done') {
+      document.getElementById('progressBar').style.width = '100%';
+      document.getElementById('progressLabel').textContent = '✅ 迭代优化完成';
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      document.getElementById('timeInfo').textContent = `已用时 ${elapsed} 秒`;
+    }
+
+    // 更新时间
+    if (data.status === 'running') {
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      document.getElementById('timeInfo').textContent = `已用时 ${elapsed} 秒`;
+    }
+  }
+
+  // 最终结果事件
+  if (data.type === 'result') {
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    document.getElementById('pipelineDesc').textContent = `🎉 全部完成！总耗时 ${elapsed} 秒`;
+
+    // 隐藏进度条
+    document.getElementById('progressSection').style.display = 'none';
+
+    // 显示结果对比
+    const resultSection = document.getElementById('resultSection');
+    document.getElementById('originalImg').src = document.getElementById('previewImg').src;
+
+    // 优先使用 base64 图片展示
+    if (data.image_base64) {
+      document.getElementById('resultImg').src = `data:image/png;base64,${data.image_base64}`;
+    } else {
+      document.getElementById('resultImg').src = `${API}${data.download_url}`;
+    }
+
+    document.getElementById('resultLabel').textContent = `${getStyleEmoji(selectedStyle)} 风格化`;
+    document.getElementById('btnDownload').href = `${API}${data.download_url}`;
+    resultSection.style.display = 'block';
+  }
 }
 
 function getStyleEmoji(key) {
@@ -405,7 +585,8 @@ function getStyleEmoji(key) {
   return map[key] || '🎨';
 }
 
-// 启动
+// 初始化
+initPipeline();
 checkHealth();
 </script>
 </body>

--- a/demos/2026-04-07_style-transfer/frontend/index.html
+++ b/demos/2026-04-07_style-transfer/frontend/index.html
@@ -13,13 +13,13 @@
     min-height: 100vh;
   }
   .container { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem; }
-
+  
   /* 顶部 */
   header { text-align: center; margin-bottom: 2rem; }
   header h1 { font-size: 2rem; margin-bottom: 0.5rem; }
   header h1 span { font-size: 2.4rem; }
   header p { color: #94a3b8; font-size: 0.95rem; }
-
+  
   /* 状态指示器 */
   .status-bar {
     display: flex; align-items: center; justify-content: center;
@@ -32,7 +32,7 @@
   }
   .status-dot.online { background: #22c55e; }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
-
+  
   /* 上传区 */
   .upload-zone {
     border: 2px dashed #334155; border-radius: 12px;
@@ -45,7 +45,7 @@
   .upload-zone .icon { font-size: 3rem; margin-bottom: 1rem; }
   .upload-zone p { color: #94a3b8; }
   .upload-zone input { display: none; }
-
+  
   /* 预览 */
   .preview-area {
     display: none; margin-bottom: 2rem; text-align: center;
@@ -57,7 +57,7 @@
   .preview-area .file-info {
     margin-top: 0.5rem; font-size: 0.85rem; color: #94a3b8;
   }
-
+  
   /* 风格选择 */
   .styles-section { margin-bottom: 2rem; }
   .styles-section h3 { margin-bottom: 1rem; font-size: 1.1rem; }
@@ -75,7 +75,7 @@
   .style-card .emoji { font-size: 2rem; margin-bottom: 0.5rem; }
   .style-card .name { font-weight: 600; margin-bottom: 0.3rem; }
   .style-card .desc { font-size: 0.8rem; color: #94a3b8; }
-
+  
   /* 开始按钮 */
   .action-bar { text-align: center; margin-bottom: 2rem; }
   .btn-transfer {
@@ -89,87 +89,88 @@
     opacity: 0.5; cursor: not-allowed; transform: none; box-shadow: none;
   }
 
-  /* ========== 动态流水线 ========== */
+  /* 动态流水线 */
   .pipeline-section {
-    display: none; margin-bottom: 2rem; padding: 1.5rem 1rem;
-    background: #1e293b; border-radius: 10px; border: 1px solid #334155;
+    display: none; margin-bottom: 2rem; padding: 1.5rem;
+    background: #1e293b; border-radius: 10px;
+    border: 1px solid #334155;
   }
-  .pipeline-section h3 {
-    text-align: center; margin-bottom: 1.2rem; font-size: 1rem;
-  }
-  /* 横向流水线容器 */
+  .pipeline-section h3 { text-align: center; margin-bottom: 1.2rem; font-size: 1rem; }
   .pipeline-track {
     display: flex; align-items: center; justify-content: center;
-    gap: 0; overflow-x: auto; padding: 0.5rem 0;
+    gap: 0; flex-wrap: nowrap; overflow-x: auto;
+    padding: 0.5rem 0;
   }
-  /* 单个步骤节点 */
   .pipeline-node {
     display: flex; flex-direction: column; align-items: center;
-    min-width: 80px; position: relative;
+    min-width: 80px; flex-shrink: 0;
   }
   .pipeline-node .node-circle {
     width: 44px; height: 44px; border-radius: 50%;
     display: flex; align-items: center; justify-content: center;
-    font-size: 1.25rem; border: 2px solid #475569;
+    font-size: 1.3rem; border: 2px solid #475569;
     background: #1e293b; transition: all 0.4s; position: relative;
   }
   .pipeline-node .node-label {
     margin-top: 0.4rem; font-size: 0.72rem; color: #64748b;
     text-align: center; white-space: nowrap; transition: color 0.4s;
   }
-  /* 节点状态：待执行（默认） */
-  .pipeline-node.pending .node-circle { border-color: #475569; color: #64748b; }
-  /* 节点状态：执行中 */
+  /* 待执行：灰色 */
+  .pipeline-node.pending .node-circle { border-color: #475569; opacity: 0.5; }
+  .pipeline-node.pending .node-label { color: #475569; }
+  /* 执行中：蓝色呼吸灯 */
   .pipeline-node.running .node-circle {
-    border-color: #38bdf8; color: #fff;
-    box-shadow: 0 0 12px rgba(56,189,248,0.5);
+    border-color: #38bdf8; background: rgba(56,189,248,0.12);
+    box-shadow: 0 0 12px rgba(56,189,248,0.4);
     animation: breathe 1.5s ease-in-out infinite;
+    opacity: 1;
   }
   .pipeline-node.running .node-label { color: #38bdf8; font-weight: 600; }
-  /* 节点状态：完成 */
+  @keyframes breathe {
+    0%, 100% { box-shadow: 0 0 8px rgba(56,189,248,0.3); }
+    50% { box-shadow: 0 0 20px rgba(56,189,248,0.6); }
+  }
+  /* 已完成：绿色 + 打勾 */
   .pipeline-node.done .node-circle {
-    border-color: #22c55e; background: #22c55e; color: #fff;
+    border-color: #22c55e; background: rgba(34,197,94,0.12);
+    opacity: 1;
   }
   .pipeline-node.done .node-label { color: #22c55e; }
-  /* 完成后显示打勾覆盖 */
   .pipeline-node.done .node-circle::after {
-    content: "✓"; position: absolute; font-size: 1.1rem; font-weight: bold;
+    content: '✓'; position: absolute; bottom: -2px; right: -2px;
+    font-size: 0.6rem; background: #22c55e; color: #fff;
+    width: 16px; height: 16px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-weight: bold;
   }
-  .pipeline-node.done .node-circle .node-emoji { visibility: hidden; }
-
-  @keyframes breathe {
-    0%, 100% { box-shadow: 0 0 8px rgba(56,189,248,0.4); }
-    50% { box-shadow: 0 0 20px rgba(56,189,248,0.7); }
+  /* 连线箭头 */
+  .pipeline-arrow {
+    width: 28px; height: 2px; background: #475569; position: relative;
+    flex-shrink: 0; margin: 0 2px; margin-bottom: 1.4rem;
+    transition: background 0.4s;
   }
-
-  /* 连接线 */
-  .pipeline-connector {
-    width: 32px; height: 2px; background: #475569;
-    flex-shrink: 0; transition: background 0.4s; margin-top: -1.2rem;
+  .pipeline-arrow::after {
+    content: ''; position: absolute; right: -1px; top: -3px;
+    border: 4px solid transparent; border-left-color: #475569;
+    transition: border-left-color 0.4s;
   }
-  .pipeline-connector.done { background: #22c55e; }
+  .pipeline-arrow.done { background: #22c55e; }
+  .pipeline-arrow.done::after { border-left-color: #22c55e; }
+  .pipeline-arrow.active { background: #38bdf8; }
+  .pipeline-arrow.active::after { border-left-color: #38bdf8; }
 
-  /* 步骤描述文字 */
+  /* 当前步骤描述 */
   .pipeline-desc {
-    text-align: center; margin-top: 1rem; font-size: 0.85rem;
-    color: #94a3b8; min-height: 1.2em; transition: color 0.3s;
+    text-align: center; margin-top: 1rem;
+    font-size: 0.88rem; color: #94a3b8; min-height: 1.4em;
+    transition: color 0.3s;
   }
+  .pipeline-desc.active { color: #38bdf8; }
 
-  /* 进度条（用于迭代优化时） */
-  .progress-section {
-    display: none; margin-bottom: 2rem; padding: 1.5rem;
-    background: #1e293b; border-radius: 10px;
-  }
-  .progress-section .label { margin-bottom: 0.8rem; font-size: 0.9rem; }
-  .progress-bar-bg {
-    height: 8px; background: #334155; border-radius: 4px; overflow: hidden;
-  }
-  .progress-bar {
-    height: 100%; background: linear-gradient(90deg, #6366f1, #a78bfa);
-    border-radius: 4px; width: 0%; transition: width 0.5s;
-  }
-  .progress-section .time-info {
-    margin-top: 0.5rem; font-size: 0.8rem; color: #94a3b8;
+  /* 进度时间 */
+  .pipeline-time {
+    text-align: center; margin-top: 0.6rem;
+    font-size: 0.8rem; color: #64748b;
   }
 
   /* 结果对比 */
@@ -186,7 +187,7 @@
   .compare-item img {
     width: 100%; border-radius: 8px; border: 1px solid #334155;
   }
-
+  
   /* 下载按钮 */
   .download-bar { text-align: center; margin-top: 1rem; }
   .btn-download {
@@ -201,11 +202,10 @@
   @media (max-width: 600px) {
     .compare-grid { grid-template-columns: 1fr; }
     .style-grid { grid-template-columns: 1fr 1fr; }
-    .pipeline-track { flex-wrap: wrap; gap: 0.3rem; justify-content: center; }
-    .pipeline-connector { width: 20px; }
     .pipeline-node { min-width: 60px; }
-    .pipeline-node .node-circle { width: 36px; height: 36px; font-size: 1rem; }
+    .pipeline-node .node-circle { width: 36px; height: 36px; font-size: 1.1rem; }
     .pipeline-node .node-label { font-size: 0.65rem; }
+    .pipeline-arrow { width: 16px; }
   }
 </style>
 </head>
@@ -251,19 +251,9 @@
   <!-- 动态流水线 -->
   <div class="pipeline-section" id="pipelineSection">
     <h3>📋 风格迁移处理流程</h3>
-    <div class="pipeline-track" id="pipelineTrack">
-      <!-- 由 JS 动态生成 -->
-    </div>
+    <div class="pipeline-track" id="pipelineTrack"></div>
     <div class="pipeline-desc" id="pipelineDesc"></div>
-  </div>
-
-  <!-- 进度条（迭代优化时的二级进度） -->
-  <div class="progress-section" id="progressSection">
-    <div class="label" id="progressLabel">⏳ 正在处理中...</div>
-    <div class="progress-bar-bg">
-      <div class="progress-bar" id="progressBar"></div>
-    </div>
-    <div class="time-info" id="timeInfo"></div>
+    <div class="pipeline-time" id="pipelineTime"></div>
   </div>
 
   <!-- 结果 -->
@@ -291,68 +281,69 @@ let fileId = null;
 let selectedStyle = null;
 let uploadedFile = null;
 
-// 6 个步骤的元信息（与后端 TRANSFER_STEPS 对应）
-const STEPS = [
-  { step: 1, emoji: '📤', name: '接收图片' },
-  { step: 2, emoji: '🔧', name: '图像预处理' },
-  { step: 3, emoji: '🧠', name: 'VGG19 特征提取' },
-  { step: 4, emoji: '📐', name: 'Gram 矩阵计算' },
-  { step: 5, emoji: '🔄', name: 'L-BFGS 迭代优化' },
-  { step: 6, emoji: '🎨', name: '输出结果' },
+// 流水线步骤定义（与后端 TRANSFER_STEPS 对应）
+const PIPELINE_STEPS = [
+  { step: 1, emoji: '📤', name: '接收图片', description: '读取上传的内容图和风格图' },
+  { step: 2, emoji: '🔧', name: '图像预处理', description: '缩放至统一尺寸并归一化' },
+  { step: 3, emoji: '🧠', name: 'VGG19 特征提取', description: '提取内容特征与风格特征' },
+  { step: 4, emoji: '📐', name: 'Gram 矩阵计算', description: '计算风格纹理的 Gram 矩阵' },
+  { step: 5, emoji: '🔄', name: 'L-BFGS 迭代优化', description: '迭代生成风格化图像' },
+  { step: 6, emoji: '🎨', name: '输出结果', description: '返回最终风格迁移图片' },
 ];
 
-// === 初始化流水线 DOM ===
+// === 流水线 UI ===
 function initPipeline() {
   const track = document.getElementById('pipelineTrack');
   track.innerHTML = '';
-  STEPS.forEach((s, i) => {
+  PIPELINE_STEPS.forEach((s, i) => {
     // 节点
     const node = document.createElement('div');
     node.className = 'pipeline-node pending';
     node.id = `pnode-${s.step}`;
-    node.innerHTML = `
-      <div class="node-circle"><span class="node-emoji">${s.emoji}</span></div>
-      <div class="node-label">${s.name}</div>
-    `;
+    node.innerHTML = `<div class="node-circle">${s.emoji}</div><div class="node-label">${s.name}</div>`;
     track.appendChild(node);
-    // 连线（最后一个步骤后面不加）
-    if (i < STEPS.length - 1) {
-      const conn = document.createElement('div');
-      conn.className = 'pipeline-connector';
-      conn.id = `pconn-${s.step}`;
-      track.appendChild(conn);
+    // 箭头（最后一个不加）
+    if (i < PIPELINE_STEPS.length - 1) {
+      const arrow = document.createElement('div');
+      arrow.className = 'pipeline-arrow';
+      arrow.id = `parrow-${s.step}`;
+      track.appendChild(arrow);
     }
   });
+  document.getElementById('pipelineDesc').textContent = '';
+  document.getElementById('pipelineDesc').classList.remove('active');
+  document.getElementById('pipelineTime').textContent = '';
 }
 
-// 更新某一步的状态
-function setPipelineStep(stepNum, status, description) {
+function updatePipelineStep(stepNum, status, description) {
   const node = document.getElementById(`pnode-${stepNum}`);
   if (!node) return;
+
+  // 更新节点状态
   node.className = `pipeline-node ${status}`;
 
-  // 如果完成，连线也变绿
-  if (status === 'done') {
-    const conn = document.getElementById(`pconn-${stepNum}`);
-    if (conn) conn.classList.add('done');
+  // 更新前面的箭头
+  if (status === 'done' && stepNum > 1) {
+    const prevArrow = document.getElementById(`parrow-${stepNum - 1}`);
+    if (prevArrow) prevArrow.className = 'pipeline-arrow done';
+  }
+  if (status === 'running' && stepNum > 1) {
+    const prevArrow = document.getElementById(`parrow-${stepNum - 1}`);
+    if (prevArrow && !prevArrow.classList.contains('done')) {
+      prevArrow.className = 'pipeline-arrow active';
+    }
   }
 
   // 更新描述
-  if (description) {
-    document.getElementById('pipelineDesc').textContent =
-      `${STEPS[stepNum - 1].emoji} ${description}`;
+  const desc = document.getElementById('pipelineDesc');
+  if (status === 'running') {
+    const stepInfo = PIPELINE_STEPS.find(s => s.step === stepNum);
+    desc.textContent = `${stepInfo ? stepInfo.emoji : ''} 步骤 ${stepNum}/6：${description || ''}`;
+    desc.classList.add('active');
+  } else if (status === 'done' && stepNum === 6) {
+    desc.textContent = '✅ 全部步骤完成！';
+    desc.classList.remove('active');
   }
-}
-
-// 重置所有流水线节点
-function resetPipeline() {
-  STEPS.forEach(s => {
-    const node = document.getElementById(`pnode-${s.step}`);
-    if (node) node.className = 'pipeline-node pending';
-    const conn = document.getElementById(`pconn-${s.step}`);
-    if (conn) conn.classList.remove('done');
-  });
-  document.getElementById('pipelineDesc').textContent = '';
 }
 
 // === 初始化 ===
@@ -424,9 +415,9 @@ fileInput.addEventListener('change', () => {
 async function handleFile(file) {
   if (!file.type.startsWith('image/')) { alert('请选择图片文件'); return; }
   if (file.size > 10*1024*1024) { alert('图片不能超过 10MB'); return; }
-
+  
   uploadedFile = file;
-
+  
   // 本地预览
   const reader = new FileReader();
   reader.onload = e => {
@@ -453,7 +444,7 @@ async function handleFile(file) {
   }
 }
 
-// === 风格迁移（SSE 版本） ===
+// === 风格迁移（SSE 流式） ===
 document.getElementById('btnTransfer').addEventListener('click', startTransfer);
 
 async function startTransfer() {
@@ -463,25 +454,26 @@ async function startTransfer() {
   btn.disabled = true;
   btn.textContent = '⏳ 处理中...';
 
-  // 显示流水线，隐藏结果
+  // 显示流水线，隐藏旧结果
   const pipelineSection = document.getElementById('pipelineSection');
   pipelineSection.style.display = 'block';
   document.getElementById('resultSection').style.display = 'none';
-  document.getElementById('progressSection').style.display = 'none';
   initPipeline();
 
   const startTime = Date.now();
+  // 定时更新耗时
+  const timer = setInterval(() => {
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    document.getElementById('pipelineTime').textContent = `已用时 ${elapsed} 秒`;
+  }, 500);
 
   try {
-    // 使用 fetch + ReadableStream 连接 SSE 接口
     const formData = new FormData();
     formData.append('file_id', fileId);
     formData.append('style', selectedStyle);
 
-    const response = await fetch(`${API}/transfer-stream`, {
-      method: 'POST',
-      body: formData,
-    });
+    // 使用 fetch + ReadableStream 消费 SSE（因为是 POST 请求，不能用 EventSource）
+    const response = await fetch(`${API}/transfer-stream`, { method: 'POST', body: formData });
 
     if (!response.ok) {
       const err = await response.json();
@@ -493,91 +485,58 @@ async function startTransfer() {
     let buffer = '';
 
     while (true) {
-      const { value, done } = await reader.read();
+      const { done, value } = await reader.read();
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });
 
-      // 按 SSE 协议解析：每条消息以 \n\n 分隔
+      // 按双换行分割 SSE 事件
       const parts = buffer.split('\n\n');
-      // 最后一段可能不完整，保留在 buffer 中
-      buffer = parts.pop() || '';
+      buffer = parts.pop(); // 最后一段可能不完整，保留
 
       for (const part of parts) {
         const trimmed = part.trim();
         if (!trimmed) continue;
 
-        // 提取 data: 后面的 JSON
-        const lines = trimmed.split('\n');
-        for (const line of lines) {
+        // 提取 data: 行
+        for (const line of trimmed.split('\n')) {
           if (line.startsWith('data: ')) {
             try {
-              const data = JSON.parse(line.slice(6));
-              handleSSEEvent(data, startTime);
-            } catch (e) {
-              console.warn('SSE 解析失败:', line, e);
+              const evt = JSON.parse(line.slice(6));
+
+              if (evt.type === 'result') {
+                // 最终结果
+                clearInterval(timer);
+                const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+                document.getElementById('pipelineTime').textContent = `总耗时 ${elapsed} 秒`;
+
+                // 显示结果
+                const resultSection = document.getElementById('resultSection');
+                document.getElementById('originalImg').src = document.getElementById('previewImg').src;
+                document.getElementById('resultImg').src = `data:image/png;base64,${evt.image_base64}`;
+                const styleName = PIPELINE_STEPS[5].name;
+                document.getElementById('resultLabel').textContent = `${getStyleEmoji(selectedStyle)} ${selectedStyle}`;
+                document.getElementById('btnDownload').href = `${API}${evt.download_url}`;
+                resultSection.style.display = 'block';
+              } else if (evt.step !== undefined) {
+                // 步骤事件
+                updatePipelineStep(evt.step, evt.status, evt.description);
+              }
+            } catch(parseErr) {
+              console.warn('SSE 解析跳过:', line, parseErr);
             }
           }
         }
       }
     }
   } catch(e) {
+    clearInterval(timer);
     document.getElementById('pipelineDesc').textContent = '❌ 处理失败：' + e.message;
-    document.getElementById('pipelineDesc').style.color = '#ef4444';
+    document.getElementById('pipelineDesc').classList.remove('active');
   }
 
   btn.disabled = false;
   btn.textContent = '✨ 开始风格迁移';
-}
-
-function handleSSEEvent(data, startTime) {
-  // 步骤事件（包含 step 字段）
-  if (data.step !== undefined && data.status) {
-    setPipelineStep(data.step, data.status, data.description);
-
-    // 步骤 5 执行中时显示进度条
-    if (data.step === 5 && data.status === 'running') {
-      document.getElementById('progressSection').style.display = 'block';
-      document.getElementById('progressLabel').textContent = '🔄 L-BFGS 迭代优化中...';
-      document.getElementById('progressBar').style.width = '10%';
-    }
-    if (data.step === 5 && data.status === 'done') {
-      document.getElementById('progressBar').style.width = '100%';
-      document.getElementById('progressLabel').textContent = '✅ 迭代优化完成';
-      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-      document.getElementById('timeInfo').textContent = `已用时 ${elapsed} 秒`;
-    }
-
-    // 更新时间
-    if (data.status === 'running') {
-      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-      document.getElementById('timeInfo').textContent = `已用时 ${elapsed} 秒`;
-    }
-  }
-
-  // 最终结果事件
-  if (data.type === 'result') {
-    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-    document.getElementById('pipelineDesc').textContent = `🎉 全部完成！总耗时 ${elapsed} 秒`;
-
-    // 隐藏进度条
-    document.getElementById('progressSection').style.display = 'none';
-
-    // 显示结果对比
-    const resultSection = document.getElementById('resultSection');
-    document.getElementById('originalImg').src = document.getElementById('previewImg').src;
-
-    // 优先使用 base64 图片展示
-    if (data.image_base64) {
-      document.getElementById('resultImg').src = `data:image/png;base64,${data.image_base64}`;
-    } else {
-      document.getElementById('resultImg').src = `${API}${data.download_url}`;
-    }
-
-    document.getElementById('resultLabel').textContent = `${getStyleEmoji(selectedStyle)} 风格化`;
-    document.getElementById('btnDownload').href = `${API}${data.download_url}`;
-    resultSection.style.display = 'block';
-  }
 }
 
 function getStyleEmoji(key) {
@@ -585,8 +544,7 @@ function getStyleEmoji(key) {
   return map[key] || '🎨';
 }
 
-// 初始化
-initPipeline();
+// 启动
 checkHealth();
 </script>
 </body>

--- a/demos/2026-04-07_style-transfer/frontend/index.html
+++ b/demos/2026-04-07_style-transfer/frontend/index.html
@@ -20,6 +20,38 @@
   header h1 span { font-size: 2.4rem; }
   header p { color: #94a3b8; font-size: 0.95rem; }
   
+  /* 设备信息面板 */
+  .device-panel {
+    display: none; margin-bottom: 1.5rem; padding: 1rem 1.2rem;
+    border-radius: 10px; border: 1px solid #334155;
+    font-size: 0.88rem; line-height: 1.6;
+  }
+  .device-panel .device-header {
+    display: flex; align-items: center; gap: 0.5rem;
+    font-weight: 600; margin-bottom: 0.5rem; font-size: 0.95rem;
+  }
+  .device-panel .device-reason { margin-bottom: 0.5rem; }
+  .device-panel .device-suggestion {
+    white-space: pre-line; font-size: 0.82rem; opacity: 0.85;
+    padding: 0.6rem 0.8rem; border-radius: 6px;
+    background: rgba(0,0,0,0.2); margin-top: 0.5rem;
+  }
+  /* GPU 已启用：绿色 */
+  .device-panel.gpu-active {
+    background: rgba(34,197,94,0.08); border-color: rgba(34,197,94,0.3);
+  }
+  .device-panel.gpu-active .device-header { color: #22c55e; }
+  /* 有 GPU 但未启用：黄色警告 */
+  .device-panel.gpu-warning {
+    background: rgba(234,179,8,0.08); border-color: rgba(234,179,8,0.3);
+  }
+  .device-panel.gpu-warning .device-header { color: #eab308; }
+  /* 无 GPU：灰色 */
+  .device-panel.cpu-only {
+    background: rgba(148,163,184,0.08); border-color: rgba(148,163,184,0.2);
+  }
+  .device-panel.cpu-only .device-header { color: #94a3b8; }
+
   /* 状态指示器 */
   .status-bar {
     display: flex; align-items: center; justify-content: center;
@@ -216,6 +248,13 @@
     <p>上传照片，用 AI 将它变成油画、素描、水彩等艺术风格</p>
   </header>
 
+  <!-- 设备信息面板 -->
+  <div class="device-panel" id="devicePanel">
+    <div class="device-header" id="deviceHeader"></div>
+    <div class="device-reason" id="deviceReason"></div>
+    <div class="device-suggestion" id="deviceSuggestion" style="display:none;"></div>
+  </div>
+
   <!-- API 状态 -->
   <div class="status-bar">
     <div class="status-dot" id="statusDot"></div>
@@ -356,8 +395,47 @@ async function checkHealth() {
     const gpu = data.gpu_available ? '🟢 GPU' : '🟡 CPU';
     document.getElementById('deviceInfo').textContent = `${gpu} | 分辨率 ${data.img_size}px`;
     loadStyles();
+    loadDeviceInfo();
   } catch {
     document.getElementById('statusText').textContent = '❌ 后端未连接，请启动 python3 app.py';
+  }
+}
+
+// 加载设备详情面板
+async function loadDeviceInfo() {
+  try {
+    const r = await fetch(`${API}/device-info`);
+    const data = await r.json();
+    const panel = document.getElementById('devicePanel');
+    const header = document.getElementById('deviceHeader');
+    const reason = document.getElementById('deviceReason');
+    const suggestion = document.getElementById('deviceSuggestion');
+
+    if (data.gpu_available) {
+      // GPU 已启用 — 绿色
+      panel.className = 'device-panel gpu-active';
+      header.innerHTML = `🟢 GPU 加速已启用 — ${data.gpu_name || 'GPU'}`;
+      reason.textContent = data.reason;
+      suggestion.style.display = 'none';
+    } else if (data.gpu_name) {
+      // 有物理 GPU 但未启用 — 黄色警告
+      panel.className = 'device-panel gpu-warning';
+      header.innerHTML = `⚠️ 检测到 GPU 但未启用`;
+      reason.textContent = data.reason;
+      suggestion.textContent = data.suggestion;
+      suggestion.style.display = 'block';
+    } else {
+      // 无 GPU — 灰色
+      panel.className = 'device-panel cpu-only';
+      header.innerHTML = `💻 使用 CPU 运算`;
+      reason.textContent = data.reason;
+      suggestion.textContent = data.suggestion;
+      suggestion.style.display = 'block';
+    }
+
+    panel.style.display = 'block';
+  } catch(e) {
+    console.error('加载设备信息失败:', e);
   }
 }
 


### PR DESCRIPTION
## 改动内容

### 第 1 步：后端 SSE 步骤推送
- 新增 `POST /transfer-stream` SSE 端点，实时推送风格迁移 6 个步骤的执行进度

### 第 2 步：前端动态步骤流水线
- 替换静态流程说明，改为动态流水线组件
- 接入 SSE，实时高亮当前步骤 + 呼吸灯动画

### 第 3 步：GPU/CPU 设备检测面板
- 新增 `GET /device-info` 端点，检测 GPU/CUDA 状态
- 前端页面顶部展示设备信息面板，告知用户为什么用的是 CPU

关联 Issue: #3